### PR TITLE
Fix instructions for testing: yarn -> npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Just add to `src/assets/` and the production build copies them to `/dist`
 `elm-test init` is run when you install your dependencies. After that all you need to do to run the tests is
 
 ```
-yarn test
+npm test
 ```
 
 Take a look at the examples in `tests/`


### PR DESCRIPTION
I presume that the testing instructions were wrong and that one should run the tests with `npm test`.